### PR TITLE
fix for when classNm is null

### DIFF
--- a/src/styler.js
+++ b/src/styler.js
@@ -58,7 +58,7 @@ export default function styler() {
     const styles = [];
     
     if(classNames){
-      parsedClassNames = findClassNames(classNames).map((classNm) => classNm.join(""));
+      parsedClassNames = findClassNames(classNames).map((classNm) => classNm ? classNm.join("") : "");
       parsedClassNames.forEach((className) => {
         styles.push(stylesBundle[className]);
       });


### PR DESCRIPTION
While using context, sometimes the classNm becomes null (or undefined, I do not remember).
In that case it is causing exception. This is a fix for that.